### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ import config as cfg
 import logging
 import uuid
 import json
-
+import os
 
 app = Flask(__name__)
 
@@ -123,4 +123,5 @@ def log():
     return jsonify({'message': 'Data added successfully', 'data': existing_data}), 201
 
 if __name__=='__main__':
-    app.run(host='0.0.0.0', port='8080', debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port='8080', debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/IBM/responsible-prompting-api/security/code-scanning/1](https://github.com/IBM/responsible-prompting-api/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode using an environment variable. This way, we can easily switch between development and production configurations without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to run in debug mode.
2. Import the `os` module to access environment variables.
3. Set the default value of the debug mode to `False` to ensure that the application does not run in debug mode by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
