### PR TITLE
Updated torch version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ sniffio==1.3.1
 tensorflow==2.16.2
 tf-keras==2.16.0
 threadpoolctl==3.5.0
-torch==2.2.2
+torch==2.6.0
 tomli==2.0.1
 typer==0.12.5
 typing_extensions==4.12.2


### PR DESCRIPTION
The project requires `torch >= 2.5` probably because of this commit in the upstream transformers library today (https://github.com/huggingface/transformers/commit/e288ee00d80f17bb645bcd1f7f8f52572a25e379)

Tested the torch version to `2.6.0` (the latest version compatible with Travis CI) and updated `requirements.txt` accordingly.