### PR TITLE
Added inference to the demo website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 # Responsible prompting API
 Responsible Prompting is an [AI Alliance affiliated project](https://thealliance.ai/affiliated-projects/responsible-prompting) providing an LLM-agnostic lightweight prompt recommender that dynamically supports users in crafting prompts that embed social values and avoid harmful prompts.
 
-This Responsible Prompting API is composed of a `Flask server` that hosts the `recommend`, `recommend_local`, `get_thresholds` routes, the `swagger` files and a responsible prompting `demo`.
-You can run the server locally to execute requests and obtain responsible prompting recommendations according to `swagger` description.
+This Responsible Prompting API is composed of a `Flask server` that hosts the `recommend`, `recommend_local`, `get_thresholds` routes, the `swagger` files and a responsible prompting `demo`. There is also an additional endpoint `demo_inference` for text completion using the HuggingFace models for use by the demo website. You can run the server locally to execute requests and obtain responsible prompting recommendations according to `swagger` description.
 
 1. [Getting started](#getting-started)
 2. [Customizing recommendations to your use case](#customizing-recommendations-to-your-use-case)
@@ -40,8 +39,7 @@ HF_TOKEN=<include-token-here>
 8. Test that the server is running by accessing http://127.0.0.1:8080/ in your browser. You should see the message 'Ready!'.
 9. Play with our demo by accessing http://127.0.0.1:8080/static/demo/index.html in your browser.
 
-### Connecting to LLMs hosted on Hugging Face
-The demo website uses an inference endpoint (`demo_inference`) which connects to models hosted on HuggingFace. While its connected to a default model for answer generation, the API takes in the following parameters: `model_id`, `temperature` and `max_tokens` as inputs allowing experimentation with models of your choice.
+The demo uses an inference endpoint (`demo_inference`) which connects to models hosted on HuggingFace. For answer generation, it uses a `Llama-4-Scout-17B-16E-Instruct` model as default, which you can change to another model of your choice. The API takes the `model_id`, `temperature` and `max_tokens` as inputs, allowing for experimentation.
 
 ### Check out the API swagger
 1. Run the server (if it is not already running)

--- a/README.md
+++ b/README.md
@@ -41,25 +41,7 @@ HF_TOKEN=<include-token-here>
 9. Play with our demo by accessing http://127.0.0.1:8080/static/demo/index.html in your browser.
 
 ### Connecting to LLMs hosted on Hugging Face
-
-1. Run the server (if it is not already running)
-2. In the [index.html](https://github.com/IBM/responsible-prompting-api/blob/main/static/demo/index.html) file, find the function for the `submit` event handler. It starts with:
-```
-$( "#demo" ).on( "submit", function( e ){ // Hugging Face
-...
-```
-> [!NOTE]
-> When customizing the `$ajax` call, please make sure that the json data follows the specifications of the LLM being used.
-
-3. Inside this function, replace `<include-token-here>` with your hugging face access token:
-```
-headers: {"Authorization": "Bearer <include-token-here>"}
-```
-
-> [!CAUTION]
-> Your Hugging Face token will be visible in the code, remember to remove the token before committing or after running the prototype to avoid displaying sensitive data. In case the token has been exposed, follow the HF [instructions to invalidate it](https://huggingface.co/docs/hub/en/security-tokens).
-
-5. In your browser, access http://127.0.0.1:8080/static/demo/index.html
+The demo website uses an inference endpoint (`demo_inference`) which connects to models hosted on HuggingFace. While its connected to a default model for answer generation, the API takes in the following parameters: `model_id`, `temperature` and `max_tokens` as inputs allowing experimentation with models of your choice.
 
 ### Check out the API swagger
 1. Run the server (if it is not already running)

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ sniffio==1.3.1
 tensorflow==2.16.2
 tf-keras==2.16.0
 threadpoolctl==3.5.0
-torch==2.2.2
+torch==2.6.0
 tomli==2.0.1
 typer==0.12.5
 typing_extensions==4.12.2

--- a/static/demo/index.html
+++ b/static/demo/index.html
@@ -390,22 +390,6 @@
 
         // Generation request
         $( "#demo" ).on( "submit", function(e){ // Hugging Face
-
-            var out = "" ;
-            const ajax_headers = {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-                'Access-Control-Allow-Headers': '*',
-                'Authorization' : 'Bearer <include-token-here>',
-            };
-            $.ajaxSetup({
-                headers: ajax_headers
-            });
-
-            if( ajax_headers['Authorization'] == "Bearer <include-token-here>" ){
-                console.error( "Please inform your authorization token in the ajax header setup." ) ;
-            }
-            else{
                 $( "#generate" ).toggleClass( "bx--btn--disabled" ) ;
                 ( function loading_animation(){
                     if( $( "#outcome" ).attr( "placeholder" ) == "" ){
@@ -420,20 +404,9 @@
                     setTimeout( loading_animation, 500 );
                 } )()
 
-                var temperature = 0.5 ;
-                var max_new_tokens = 1000 ;
-                var model_id = "meta-llama/Llama-3.2-11B-Vision-Instruct"
                 $.ajax({
-                    type: "POST",
-                    url: "https://api-inference.huggingface.co/models/" + model_id,
-                    data: JSON.stringify({
-                                    "inputs":  $("#prompt").val(),
-                                    "parameters": {
-                                        "temperature": temperature,
-                                        "max_new_tokens": max_new_tokens
-                                    }
-                                }),
-                    crossDomain: true,
+                    url: encodeURI("/demo_inference?prompt=" + $("#prompt").val()),
+                    dataType: 'json',
                     success: function(data){
                         // Resetting the status of the button
                         $( "#generate" ).toggleClass( "bx--btn--disabled" ) ;
@@ -444,7 +417,10 @@
                             $( "#demo" ).data( "timeoutId", "" ) ;
                         }
 
-                        out = data[0].generated_text.split("");
+                        out = data.content.split("");
+                        model_id = data.model_id;
+                        temperature = data.temperature
+                        max_new_tokens = data.max_new_tokens
 
                         $( "#outcome" ).append( "\n\n+ ------------------------------------\n| Model: " + model_id + "\n| Temperature: " + temperature + "\n| Max new tokens: " + max_new_tokens + "\n+ ------------------------------------\n\n" ) ;
                         // Animating the generated output
@@ -456,9 +432,12 @@
                                 $( "#demo" ).data( "timeoutId", timeoutId ) ;
                             }
                         } )()
+                    },
+                    error: function(data) {
+                        out = data.responseJSON.error.message
+                        $( "#outcome" ).val(out);
                     }
-                });
-            }
+                })
             // Returning false so the form keeps user in the same page
             return false;
         });

--- a/static/swagger.json
+++ b/static/swagger.json
@@ -214,6 +214,64 @@
           }
         }
       }
+    },
+    "/demo_inference": {
+      "get": {
+        "tags": [
+          "demo_inference"
+        ],
+        "summary": "Obtain a response to the user query from LLMs hosted on HuggingFace.",
+        "description": "Given an input prompt, returns the response from text completion using LLMs hosted on HuggingFace.",
+        "parameters": [
+          {
+            "name": "prompt",
+            "in": "query",
+            "description": "Text input used to generate a response.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model_id",
+            "in": "query",
+            "description": "The id from HuggingFace of the LLM to be accessed. The default choice is: meta-llama/Llama-4-Scout-17B-16E-Instruct",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "meta-llama/Llama-4-Scout-17B-16E-Instruct"
+          },
+          {
+            "name": "max_new_tokens",
+            "in": "query",
+            "description": "An upper bound for the number of tokens that can be generated for a response",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "1000"
+          },
+          {
+            "name": "temperature",
+            "in": "query",
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "0.5"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful text completion"
+          },
+          "404": {
+            "description": "invalid input parameters or model unavailable"
+          }
+        }    
+      }
     }
   }
 }


### PR DESCRIPTION
Added an endpoint (`/demo_inference`) to serve inference requests in the Flask API.
Connected the demo UI to use this endpoint for inference.