### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Deploy App to Code Engine
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/IBM/responsible-prompting-api/security/code-scanning/3](https://github.com/IBM/responsible-prompting-api/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations on the repository, the permissions can be limited to `contents: read`. This ensures that the `GITHUB_TOKEN` has only the minimal access required to complete the workflow tasks.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow. This avoids redundancy and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
