### PR TITLE
Added Replicate support for `demo_inference`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, make sure you have:
 - A Hugging Face access token: https://huggingface.co/docs/hub/en/security-tokens
 
 > [!NOTE]  
-> Using models on [Replicate](https://replicate.com/) is also supported, but requires a billing account. On Replicate, you can access models like [Granite 3.3](https://replicate.com/ibm-granite/granite-3.3-8b-instruct), [Claude 3.7 Sonnet](https://replicate.com/anthropic/claude-3.7-sonnet), [GPT-4o](https://replicate.com/openai/gpt-4o), etc... that are not available on HuggingFace.
+> If you want to use models that are not available on HuggingFace such as [Granite 3.3](https://replicate.com/ibm-granite/granite-3.3-8b-instruct), [Claude 3.7 Sonnet](https://replicate.com/anthropic/claude-3.7-sonnet), or [GPT-4o](https://replicate.com/openai/gpt-4o), [Replicate](https://replicate.com/) is already supported. Just be aware that it requires a billing account. If there is another model hub you would like support for, you can open a pull request and the team will add it.
 
 ### Start the server:
 1. In your terminal, clone this repository and `cd` into `responsible-prompting-api` folder

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, make sure you have:
 - A Hugging Face access token: https://huggingface.co/docs/hub/en/security-tokens
 
 > [!NOTE]  
-> If you want to use models that are not available on HuggingFace such as [Granite 3.3](https://replicate.com/ibm-granite/granite-3.3-8b-instruct), [Claude 3.7 Sonnet](https://replicate.com/anthropic/claude-3.7-sonnet), or [GPT-4o](https://replicate.com/openai/gpt-4o), [Replicate](https://replicate.com/) is already supported. Just be aware that it requires a billing account. If there is another model hub you would like support for, you can open a pull request and the team will add it.
+> If you want to use models that are not available on HuggingFace such as [Granite 3.3](https://replicate.com/ibm-granite/granite-3.3-8b-instruct), [Claude 3.7 Sonnet](https://replicate.com/anthropic/claude-3.7-sonnet), or [GPT-4o](https://replicate.com/openai/gpt-4o), [Replicate](https://replicate.com/) is already supported. Just be aware that it requires a billing account. If there is another model hub you would like support for, you can open a pull request and the team will access it.
 
 ### Start the server:
 1. In your terminal, clone this repository and `cd` into `responsible-prompting-api` folder

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ First, make sure you have:
 - A machine with python 3.9 installed
 - A Hugging Face access token: https://huggingface.co/docs/hub/en/security-tokens
 
+> [!NOTE]  
+> Using models on [Replicate](https://replicate.com/) is also supported, but requires a billing account. On Replicate, you can access models like [Granite 3.3](https://replicate.com/ibm-granite/granite-3.3-8b-instruct), [Claude 3.7 Sonnet](https://replicate.com/anthropic/claude-3.7-sonnet), [GPT-4o](https://replicate.com/openai/gpt-4o), etc... that are not available on HuggingFace.
+
 ### Start the server:
 1. In your terminal, clone this repository and `cd` into `responsible-prompting-api` folder
 2. Create a virtual environment with `python -m venv <name-of-your-venv>`
@@ -31,7 +34,7 @@ First, make sure you have:
 > This usually solves most common issues.
 
 5. Rename the `env` to `.env` (please note the dot at the beginning)
-6. In the `.env` file, replace `<include-token-here>` with your Hugging Face access token:
+6. In the `.env` file, replace `<include-token-here>` with your Hugging Face (or Replicate) access token:
 ```
 HF_TOKEN=<include-token-here>
 ```

--- a/env
+++ b/env
@@ -1,2 +1,3 @@
 HF_TOKEN=<include-token-here>
 HF_URL=https://api-inference.huggingface.co/models/
+REPLICATE_TOKEN=<include-token-here>

--- a/helpers/get_credentials.py
+++ b/helpers/get_credentials.py
@@ -28,7 +28,7 @@ __version__ = "0.0.1"
 import os
 import sys
 
-def get_credentials():
+def get_hf_credentials():
     """
     Function that loads HF credentials from env file.
     The function exits the app if HF token is missing.
@@ -61,3 +61,28 @@ def get_credentials():
         print('Please include your HF_URL in the .env file')
         return hf_token, default_hf_url
     return hf_token, hf_url
+
+def get_replicate_credentials():
+    """
+    Function that loads Replicate credentials from env file.
+    The function exits the app if Replicate token is missing.
+
+    Args:
+        None.
+
+    Returns:
+        repl_token: personal Replicate token.
+
+    Raises:
+        ValueError when repl_token
+        values is missing or incorrect.
+    """
+    try:
+        repl_token = os.environ.get('REPLICATE_TOKEN')
+        if not repl_token or repl_token == '<include-token-here>':
+           raise ValueError
+    except:
+        print('Please include your REPLICATE_TOKEN in the .env file')
+        sys.exit(1)
+    
+    return repl_token

--- a/helpers/inference.py
+++ b/helpers/inference.py
@@ -1,0 +1,66 @@
+from helpers import get_credentials
+import requests
+
+def hf_inference(prompt, model_id, temperature, max_new_tokens):
+
+    hf_token, _ = get_credentials.get_hf_credentials()
+
+    API_URL = "https://router.huggingface.co/together/v1/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {hf_token}",
+    }
+
+    response = requests.post(
+        API_URL,
+        headers=headers, 
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": prompt
+                        },
+                    ]
+                }
+            ],
+            "model": model_id,
+            'temperature': temperature,
+            'max_new_tokens': max_new_tokens,
+        }
+    )
+    
+    return response.json()["choices"][0]["message"]
+
+def replicate_inference(prompt, model_id, temperature, max_new_tokens):
+
+    repl_token = get_credentials.get_replicate_credentials()
+
+    API_URL = f"https://api.replicate.com/v1/models/{model_id}/predictions"
+    headers = {
+        "Authorization": f"Bearer {repl_token}",
+        "Content-Type": "application/json",
+        "Prefer": "wait"
+    }
+
+    response = requests.post(
+        API_URL,
+        headers=headers, 
+        json={
+            "input": {
+                "prompt": prompt,
+                "temperature": temperature,
+                "max_tokens": max_new_tokens,
+            }
+        }
+    )
+
+    return {
+        "content": "".join(response.json()['output'])
+    }
+
+INFERENCE_HANDLER = {
+    'huggingface': hf_inference,
+    'replicate': replicate_inference
+}

--- a/static/demo/js/main.js
+++ b/static/demo/js/main.js
@@ -338,8 +338,11 @@ function generateResponse(rawText, chatId, sendBtnId) {
     });
     fullPrompt += "Assistant: ";
 
+    modelId = selectedModel.id;
+    inference_provider = selectedModel.inference_provider;
+
     $.ajax({
-        url: "/demo_inference?prompt=" + encodeURIComponent(fullPrompt) + "&model_id=" + encodeURIComponent(modelId),
+        url: "/demo_inference?prompt=" + encodeURIComponent(fullPrompt) + "&model_id=" + encodeURIComponent(modelId) + "&inference_provider=" + encodeURIComponent(inference_provider),
         dataType: "json",
         success: async function (data) {
             $("#typing").remove();
@@ -350,7 +353,7 @@ function generateResponse(rawText, chatId, sendBtnId) {
 
             const modelHeader = $("<div style='display: flex; flex-direction: row;'>")
                 .addClass("model-info")
-                .html(`<img src="./imgs/granite.svg" class='icon'/> <div style='display:flex; align-items: center;margin-left: 0.5rem'>${modelId}</div>`);
+                .html(`<img src="./imgs/granite.svg" class='icon'/> <div style='display:flex; align-items: center;margin-left: 0.5rem'>${modelId} (via ${inference_provider})</div>`);
             $(chatId).append(modelHeader);
 
             appendAssistantTurn("", chatId, "assistantBubble")

--- a/static/demo/multiturn.html
+++ b/static/demo/multiturn.html
@@ -69,13 +69,14 @@
         </div>
 
     <script>
-        var modelId = '';
+        var selectedModel = '';
         document.addEventListener('DOMContentLoaded', () => {
             // Populate the different models options
             // id -> id of the model on HF, name -> name displayed to the user
             const models = [
-                { id: 'mistralai/Mistral-7B-Instruct-v0.3', name: 'Mistral 7B Instruct v0.3' },
-                { id: 'meta-llama/Llama-4-Scout-17B-16E-Instruct', name: 'Llama 4 Scout' },
+                { id: 'ibm-granite/granite-3.3-8b-instruct', name: 'Granite 3.3 8B Instruct', inference_provider: 'replicate'},
+                { id: 'mistralai/Mistral-7B-Instruct-v0.3', name: 'Mistral 7B Instruct v0.3', inference_provider: 'huggingface' },
+                { id: 'meta-llama/Llama-4-Scout-17B-16E-Instruct', name: 'Llama 4 Scout', inference_provider: 'huggingface'  },
             ];
             const modelSelect = document.getElementById('modelSelect');
 
@@ -87,12 +88,11 @@
             });
 
             // Set default selection
-            modelId = models[0].id;
+            selectedModel = models[0];
 
             // Record when model changes
             modelSelect.addEventListener('change', function() {
-                const selectedModel = models.find(model => model.id === this.value);
-                modelId = selectedModel.id;
+                selectedModel = models.find(model => model.id === this.value);
             });
         });
 


### PR DESCRIPTION
Added Replicate platform support. Now we can access granite models for inference.
This is also useful for accessing other SoTA models like GPT, Claude, etc... through Replicate when we perform a user study.

The REPLICATE_TOKEN is imported only when/if the user chooses a model that runs on that platform. So, OSS contributors can still continue to run the demo/test the system without needing one.