### PR TITLE
Optimized embeddings generation

### DIFF
--- a/customize/customize_embeddings.py
+++ b/customize/customize_embeddings.py
@@ -43,7 +43,27 @@ json_in_file_name = json_in_file.split(".json")[0]
 # OUTPUT FILE
 json_out_file_name = f'{json_in_file_name}-{model_id}.json'
 
+# check if the output file already exists
+if os.path.exists(json_out_file_name):
+    try:
+        # Load existing data from the output file
+        existing_data = customize_helper.load_json(json_out_file_name)
+    except Exception as e:
+        existing_data = None
+
+# hashmap 
+prompts_embeddings = {}
+if existing_data:
+    for d in existing_data["positive_values"]:
+        for p in d["prompts"]:
+            prompts_embeddings[p["text"]] = p["embedding"]
+    for d in existing_data["negative_values"]:
+        for p in d["prompts"]:
+            prompts_embeddings[p["text"]] = p["embedding"]
+
+
+
 prompt_json = json.load(open(json_in_file))
-prompt_json_embeddings = customize_helper.populate_embeddings(prompt_json, model_path)
+prompt_json_embeddings = customize_helper.populate_embeddings(prompt_json, model_path, prompts_embeddings)
 prompt_json_centroids = customize_helper.populate_centroids(prompt_json_embeddings)
 customize_helper.save_json(prompt_json_centroids, json_out_file_name)

--- a/customize/customize_helper.py
+++ b/customize/customize_helper.py
@@ -129,7 +129,7 @@ def populate_centroids(prompt_json):
         v['centroid'] = get_centroid(v, dimension = 384, k = 10)
     return prompt_json
 
-    # Saving the embeddings for a specific LLM
+# Saving the embeddings for a specific LLM
 def save_json(prompt_json, json_out_file_name):
     with open(json_out_file_name, 'w') as outfile:
         json.dump(prompt_json, outfile)

--- a/customize/customize_helper.py
+++ b/customize/customize_helper.py
@@ -91,10 +91,13 @@ def get_centroid(v, dimension = 384, k = 10):
             i += 1
     return centroid
 
-def populate_embeddings(prompt_json, model_path):
-    errors, successess = 0, 0
+def populate_embeddings(prompt_json, model_path, prompts_embeddings):
+    errors, successes = 0, 0
     for v in prompt_json['positive_values']:
         for p in v['prompts']:
+            if (p['text'] in prompts_embeddings):
+                p['embedding'] = prompts_embeddings[p['text']]
+            else:            
                 if( p['text'] != '' and p['embedding'] == []): # only considering missing embeddings
                     embedding = query_model(p['text'], model_path)
                     if( 'error' in embedding ):
@@ -106,14 +109,17 @@ def populate_embeddings(prompt_json, model_path):
 
     for v in prompt_json['negative_values']:
         for p in v['prompts']:
-            if(p['text'] != '' and p['embedding'] == []):
-                embedding = query_model(p['text'], model_path)
-                if('error' in embedding):
-                    p['embedding'] = []
-                    errors += 1
-                else:
-                    p['embedding'] = embedding.tolist()
-                    #successes += 1
+            if (p['text'] in prompts_embeddings):
+                p['embedding'] = prompts_embeddings[p['text']]
+            else:
+                if(p['text'] != '' and p['embedding'] == []):
+                    embedding = query_model(p['text'], model_path)
+                    if('error' in embedding):
+                        p['embedding'] = []
+                        errors += 1
+                    else:
+                        p['embedding'] = embedding.tolist()
+                        #successes += 1
     return prompt_json
 
 def populate_centroids(prompt_json):
@@ -127,3 +133,11 @@ def populate_centroids(prompt_json):
 def save_json(prompt_json, json_out_file_name):
     with open(json_out_file_name, 'w') as outfile:
         json.dump(prompt_json, outfile)
+
+# load existing data from a JSON file
+def load_json(json_out_file):
+    if os.path.exists(json_out_file):
+        with open(json_out_file, 'r') as infile:
+            return json.load(infile)
+    else:
+        return None


### PR DESCRIPTION
Addressing: https://github.com/IBM/responsible-prompting-api/issues/115

I have modified `customize_helper.py` and `customize_embeddings.py` to generate embeddings' of only the _newly-added/modified_ prompts using a hashmap for comparison.

I tested out the old and new versions both in [this notebook](https://github.com/Ayesha-Imr/responsible-prompting-api/blob/test-optimize-embeddings-generation/cookbook/test_embeddings.ipynb). For testing, I used [JailbreakBench](https://huggingface.co/datasets/JailbreakBench/JBB-Behaviors) dataset which contains 100 rows of 'benign' and 'harmful' prompts each, sorted into different categories. 
As evident in the notebook, the new code generates embeddings approximately 11 times faster for the same number of newly-added prompts.

I used the 'harmful' split to test the old, unoptimized version of embeddings' generation code. I mapped the dataset categories to the best-matching existing labels in 'negative_values' and created one new one. The markdown in the notebook explains everything.

Similarly, the 'benign' split was used to test the new, optimized version of embeddings' generation code. I created one new label in 'positive_values' which fits the prompts in this split. The markdown in the notebook explains everything.

Note that in the PR, only the optimized `customize_helper.py` and `customize_embeddings.py` files are included. I have not added the `prompt_sentences.json` and `prompt_sentences-all-minilm-l6-v2.json` files with the Jailbreakbench dataset prompts + embeddings to the PR. The maintainers can check out these files in [this branch](https://github.com/Ayesha-Imr/responsible-prompting-api/tree/test-optimize-embeddings-generation) of my fork to approve these files with the new additions, and if approved, I'll create another PR to merge them to main.
But for now, the main purpose is to merge the optimized embeddings generation code (in `customize_helper.py` and `customize_embeddings.py`).