### PR TITLE
Fix get_thresholds route argument handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,13 +134,20 @@ def recommend():
 @app.route("/get_thresholds", methods=['GET'])
 @cross_origin()
 def get_thresholds():
-    hf_token, hf_url = get_credentials.get_hf_credentials()
-    api_url, headers = authenticate_api.authenticate_api(hf_token, hf_url)
     prompt_json = recommendation_handler.populate_json()
-    args = request.args
-    prompt = args.get("prompt")
-    thresholds_json = recommendation_handler.get_thresholds(prompt, prompt_json, api_url, headers)
-    return thresholds_json
+    prompts = [
+        prompt.strip()
+        for prompt in request.args.getlist("prompts")
+        if prompt.strip()
+    ]
+    if not prompts:
+        return jsonify({"error": "Missing required query parameter: prompts"}), 400
+
+    model_id = request.headers.get("model_id") or "./models/all-MiniLM-L6-v2/"
+    embedding_fn = recommendation_handler.get_embedding_func(inference='local', model_id=model_id)
+
+    thresholds_json = recommendation_handler.get_thresholds(prompts, prompt_json, embedding_fn)
+    return jsonify({key: float(value) for key, value in thresholds_json.items()})
 
 @app.route("/recommend_local", methods=['GET'])
 @cross_origin()

--- a/static/swagger.json
+++ b/static/swagger.json
@@ -99,22 +99,31 @@
           {
             "name": "prompts",
             "in": "query",
-            "description": "Prompt array.",
+            "description": "One or more prompt samples used to estimate recommendation thresholds. Repeat this query parameter to provide multiple prompts.",
             "required": true,
             "schema": {
-              "type": "string",
-              "maxLength": 1024
-            }
+              "type": "array",
+              "items": {
+                "type": "string",
+                "maxLength": 1024
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "example": [
+              "Act as a data scientist. Help me make this project more inclusive.",
+              "What evidence should I gather to support my request for more resources?"
+            ]
           },
           {
             "name": "model_id",
             "in": "header",
-            "description": "The model id to be used. The default choice is: sentence-transformers/all-minilm-l6-v2",
+            "description": "The local model path or Hugging Face model id to be used. If omitted, the default local model path is ./models/all-MiniLM-L6-v2/.",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "example": "sentence-transformers/all-minilm-l6-v2"
+            "example": "./models/all-MiniLM-L6-v2/"
           }
         ],
         "responses": {

--- a/tests/test_get_thresholds_route.py
+++ b/tests/test_get_thresholds_route.py
@@ -1,0 +1,127 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import app as app_module
+
+
+def test_get_thresholds_requires_prompts():
+    app_module.app.config["TESTING"] = True
+    client = app_module.app.test_client()
+
+    response = client.get("/get_thresholds")
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Missing required query parameter: prompts"
+    }
+
+
+def test_get_thresholds_uses_prompt_samples_and_embedding_function(monkeypatch):
+    captured = {}
+
+    def fake_populate_json():
+        return {"positive_values": [], "negative_values": []}
+
+    def fake_get_embedding_func(inference, model_id):
+        captured["inference"] = inference
+        captured["model_id"] = model_id
+        return "embedding-fn"
+
+    def fake_get_thresholds(prompts, prompt_json, embedding_fn):
+        captured["prompts"] = prompts
+        captured["prompt_json"] = prompt_json
+        captured["embedding_fn"] = embedding_fn
+        return {
+            "add_lower_threshold": 0.3,
+            "add_higher_threshold": 0.5,
+            "remove_lower_threshold": 0.1,
+            "remove_higher_threshold": 0.5,
+        }
+
+    monkeypatch.setattr(
+        app_module.recommendation_handler,
+        "populate_json",
+        fake_populate_json,
+    )
+    monkeypatch.setattr(
+        app_module.recommendation_handler,
+        "get_embedding_func",
+        fake_get_embedding_func,
+    )
+    monkeypatch.setattr(
+        app_module.recommendation_handler,
+        "get_thresholds",
+        fake_get_thresholds,
+    )
+
+    app_module.app.config["TESTING"] = True
+    client = app_module.app.test_client()
+
+    response = client.get(
+        "/get_thresholds",
+        query_string=[
+            ("prompts", "first prompt"),
+            ("prompts", "  "),
+            ("prompts", "second prompt"),
+        ],
+        headers={"model_id": "custom-model"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "add_lower_threshold": 0.3,
+        "add_higher_threshold": 0.5,
+        "remove_lower_threshold": 0.1,
+        "remove_higher_threshold": 0.5,
+    }
+    assert captured == {
+        "inference": "local",
+        "model_id": "custom-model",
+        "prompts": ["first prompt", "second prompt"],
+        "prompt_json": {"positive_values": [], "negative_values": []},
+        "embedding_fn": "embedding-fn",
+    }
+
+
+def test_get_thresholds_defaults_to_local_model(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        app_module.recommendation_handler,
+        "populate_json",
+        lambda: {},
+    )
+
+    def fake_get_embedding_func(inference, model_id):
+        captured["model_id"] = model_id
+        return "embedding-fn"
+
+    monkeypatch.setattr(
+        app_module.recommendation_handler,
+        "get_embedding_func",
+        fake_get_embedding_func,
+    )
+    monkeypatch.setattr(
+        app_module.recommendation_handler,
+        "get_thresholds",
+        lambda prompts, prompt_json, embedding_fn: {
+            "add_lower_threshold": 0.3,
+            "add_higher_threshold": 0.5,
+            "remove_lower_threshold": 0.1,
+            "remove_higher_threshold": 0.5,
+        },
+    )
+
+    app_module.app.config["TESTING"] = True
+    client = app_module.app.test_client()
+
+    response = client.get(
+        "/get_thresholds",
+        query_string={"prompts": "prompt sample"},
+    )
+
+    assert response.status_code == 200
+    assert captured["model_id"] == "./models/all-MiniLM-L6-v2/"


### PR DESCRIPTION
## Summary

Fixes the documented `GET /get_thresholds` endpoint so it no longer returns `500 Internal Server Error` when called from Swagger UI.

The route previously read `prompt` while Swagger documents `prompts`, then passed raw Hugging Face API URL/header values into `recommendation_handler.get_thresholds()`. That helper expects an embedding function as its third argument.

## Changes

- Read repeated `prompts` query parameters from `/get_thresholds`
- Return `400` when prompt samples are missing or empty
- Build a local embedding function before calling `recommendation_handler.get_thresholds()`
- Update Swagger docs to describe repeated `prompts` query parameters
- Add focused route tests for `/get_thresholds`

## Testing

```bash
uv run pytest -q
```

Result:

```text
6 passed
```

Manual Swagger test:

```bash
curl -X GET \
  'http://127.0.0.1:8080/get_thresholds?prompts=Act%20as%20a%20data%20scientist.%20Help%20me%20make%20this%20project%20more%20inclusive.&prompts=What%20evidence%20should%20I%20gather%20to%20support%20my%20request%20for%20more%20resources%3F' \
  -H 'accept: */*' \
  -H 'model_id: sentence-transformers/all-minilm-l6-v2'
```

Returned threshold JSON successfully:

```json
{
  "add_higher_threshold": 0.5,
  "add_lower_threshold": 0.5,
  "remove_higher_threshold": 0.5,
  "remove_lower_threshold": 0.3
}
```

## Issue

Fixes #138
